### PR TITLE
feat(song-management): #54 add biography value object

### DIFF
--- a/src/SongManagement/Domain/Model/Contributor/Biography.php
+++ b/src/SongManagement/Domain/Model/Contributor/Biography.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SongManagement\Domain\Model\Contributor;
+
+use App\Shared\StringValueObjectInterface;
+
+class Biography
+{
+    use StringValueObjectInterface;
+}

--- a/tests/SongManagement/Domain/Model/Contributor/BiographyTest.php
+++ b/tests/SongManagement/Domain/Model/Contributor/BiographyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\SongManagement\Domain\Model\Contributor;
+
+use App\SongManagement\Domain\Model\Contributor\Biography;
+use PHPUnit\Framework\TestCase;
+
+final class BiographyTest extends TestCase
+{
+    public function testcreatesFromString(): void
+    {
+        $biography = new Biography('A talented musician.');
+
+        self::assertInstanceOf(Biography::class, $biography);
+    }
+
+    public function testreturnsTheValue(): void
+    {
+        $biography = new Biography('A talented musician.');
+
+        self::assertSame('A talented musician.', $biography->value());
+    }
+
+    public function testconvertsToStringWithMagicMethod(): void
+    {
+        $biography = new Biography('A talented musician.');
+
+        self::assertSame('A talented musician.', (string) $biography);
+    }
+
+    public function testacceptsEmptyString(): void
+    {
+        $biography = new Biography('');
+
+        self::assertSame('', $biography->value());
+    }
+}


### PR DESCRIPTION
## 📝 Description
This PR implements sub-issue #54. It focuses on **the Domain Model implementation for Contributor Biographies**.

Specifically, it introduces the `Biography` Value Object. This encapsulates the concept of a biography string, preventing primitive obsession and preparing the ground for potential future validation rules (e.g., character limits or sanitization) within the Domain layer.

## 🧪 Notable Changes
- [x] Created `Biography` Value Object in `SongManagement\Domain\Model\Contributor`.
- [x] Leveraged `StringValueObjectInterface` for standard behavior (equality, string conversion).
- [x] Enforced strict types.

## 📸 Proof of Concept (Usage Example)

## 🔗 Links
- **Parent Issue:** #34
- **Sub-issue:** #54 
